### PR TITLE
Update JVM-SDK to version 1.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.2.RELEASE</version>
+        <version>1.5.10.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>1.11</version>
         </dependency>
 
         <!-- Compile time validation -->

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <commercetools-jvm-sdk.version>1.6.0</commercetools-jvm-sdk.version>
+        <commercetools-jvm-sdk.version>1.30.0</commercetools-jvm-sdk.version>
     </properties>
 
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.commercetools.payment-to-order-processor</groupId>
     <artifactId>payment-to-order-processor</artifactId>
-    <version>0.4</version>
+    <version>1.0.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/MessageProcessorIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/MessageProcessorIntegrationTest.java
@@ -70,11 +70,11 @@ public class MessageProcessorIntegrationTest extends IntegrationTest {
                     .withShippingAddress(address));
             final Cart cartWithPayment = testClient.executeBlocking(CartUpdateCommand.of(cart, AddPayment.of(payment)));
 
-            final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).build();
+            final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).state(TransactionState.INITIAL).build();
             final AddTransaction addTransaction = AddTransaction.of(transactionDraft);
 
             final Payment paymentWithTransaction = testClient.executeBlocking(PaymentUpdateCommand.of(payment, addTransaction));
-            assertThat(paymentWithTransaction.getTransactions().get(0).getState()).isEqualTo(TransactionState.PENDING);
+            assertThat(paymentWithTransaction.getTransactions().get(0).getState()).isEqualTo(TransactionState.INITIAL);
 
             final Transaction transaction = paymentWithTransaction.getTransactions().get(0);
             final ChangeTransactionState changeTransactionState = ChangeTransactionState.of(TransactionState.SUCCESS, transaction.getId());

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/MessageReaderIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/MessageReaderIntegrationTest.java
@@ -51,10 +51,10 @@ public class MessageReaderIntegrationTest extends IntegrationTest {
         PaymentFixtures.withPayment(testClient, payment-> {
 
             //Preconditions create message in commercetoolsplatform:
-            final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).build();
+            final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).state(TransactionState.INITIAL).build();
             final AddTransaction addTransaction = AddTransaction.of(transactionDraft);
             final Payment paymentWithTransaction = testClient.executeBlocking(PaymentUpdateCommand.of(payment, addTransaction));
-            assertThat(paymentWithTransaction.getTransactions().get(0).getState()).isEqualTo(TransactionState.PENDING);
+            assertThat(paymentWithTransaction.getTransactions().get(0).getState()).isEqualTo(TransactionState.INITIAL);
 
             final Transaction transaction = paymentWithTransaction.getTransactions().get(0);
             final ChangeTransactionState changeTransactionState = ChangeTransactionState.of(TransactionState.SUCCESS, transaction.getId());

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/helper/CartAndMessageCreateHelper.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/helper/CartAndMessageCreateHelper.java
@@ -67,11 +67,11 @@ public class CartAndMessageCreateHelper {
                 .withShippingAddress(address));
         final Cart cartWithPayment = testClient.executeBlocking(CartUpdateCommand.of(cart, AddPayment.of(payment)));
 
-        final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).build();
+        final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).state(TransactionState.INITIAL).build();
         final AddTransaction addTransaction = AddTransaction.of(transactionDraft);
 
         final Payment paymentWithTransaction = testClient.executeBlocking(PaymentUpdateCommand.of(payment, addTransaction));
-        assertThat(paymentWithTransaction.getTransactions().get(0).getState()).isEqualTo(TransactionState.PENDING);
+        assertThat(paymentWithTransaction.getTransactions().get(0).getState()).isEqualTo(TransactionState.INITIAL);
 
         final Transaction transaction = paymentWithTransaction.getTransactions().get(0);
         final ChangeTransactionState changeTransactionState = ChangeTransactionState.of(TransactionState.SUCCESS, transaction.getId());


### PR DESCRIPTION
I have set the inital State of a Transaction explcit to "initial", to follow this deprecation message:

` Deprecation notice : The default value for the 'state' field will be changed from 'Pending' to 'Initial'. Please do not depend on the default value, but provide the expected value.`