### PR TITLE
26 fix pagination timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sevice has to be scheduled and executed i.e.: every 5 minutes. This can be achie
 
 ### Configure first processed message time bound
 
-If run the service first time by default the service tries to fetch **ALL** the messages from the project,
+If the service runs for the first time by default the service tries to fetch **ALL** the messages from the project,
 which is usually not intended/expected and a customer wants to process payments only for the last couple of days/hours.
 
 In this case **`lastUpdated`** key should be set in

--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ docker run commercetools/payment-to-order-processor:latest
 ```
 Sevice has to be scheduled and executed i.e.: every 5 minutes. This can be achieved by using simple cron or services like iron.io.
 
+### Configure first processed message time bound
+
+If run the service first time by default the service tries to fetch **ALL** the messages from the project,
+which is usually not intended/expected and a customer wants to process payments only for the last couple of days/hours.
+
+In this case **`lastUpdated`** key should be set in
+[Custom Objects](https://docs.commercetools.com/http-api-projects-custom-objects.html#custom-objects)
+endpoint to desired _first processed message (payment)_ time limit.
+
+In the example below we want to start messages processing from _Friday, April 6, 2018 00:00:00 GMT_
+(**Note**: CTP stores dates in GMT timezone)
+
+```json
+{
+  "container": "commercetools-payment-to-order-processor",
+  "key": "lastUpdated",
+  "value": {
+    "lastTimeStamp": "2018-04-06T00:00:00.000Z"
+  }
+}
+```
+
 ## Congfiguration values
 ### Required values
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.commercetools.payment-to-order-processor</groupId>
     <artifactId>payment-to-order-processor</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/customobjects/MessageProcessedManagerImpl.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/customobjects/MessageProcessedManagerImpl.java
@@ -7,8 +7,6 @@ import io.sphere.sdk.customobjects.commands.CustomObjectUpsertCommand;
 import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
 import io.sphere.sdk.messages.Message;
 import io.sphere.sdk.queries.PagedQueryResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -20,8 +18,6 @@ import java.util.List;
  * @author mht@dotsource.de
  */
 public class MessageProcessedManagerImpl implements MessageProcessedManager {
-
-    public static final Logger LOG = LoggerFactory.getLogger(MessageProcessedManagerImpl.class);
 
     @Autowired
     private BlockingSphereClient client;

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
@@ -70,7 +70,7 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
                     messageProcessedManager.setMessageIsProcessed(message);
                 }
             } else {
-                LOG.debug("PaymentTransactionStateChangedMessage {} has incorrect Transaction state to be processed.", message.getId());
+                LOG.debug("PaymentTransactionStateChangedMessage {} has incorrect transaction state to be processed.", message.getId());
                 messageProcessedManager.setMessageIsProcessed(message);
             }
         } else {

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
@@ -2,6 +2,7 @@ package com.commercetools.paymenttoorderprocessor.jobs.actions;
 
 import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
 import com.commercetools.paymenttoorderprocessor.paymentcreationconfigurationmanager.PaymentCreationConfigurationManager;
+import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
 import com.commercetools.paymenttoorderprocessor.wrapper.CartAndMessage;
 import io.sphere.sdk.carts.Cart;
 import io.sphere.sdk.carts.CartState;
@@ -39,6 +40,9 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
     @Autowired
     private PaymentCreationConfigurationManager paymentCreationConfigurationManager;
 
+    @Autowired
+    private TimeStampManager timeStampManager;
+
     @Override
     public CartAndMessage process(PaymentTransactionStateChangedMessage message) {
         LOG.debug("Called MessageFilter.process with parameter {}", message);
@@ -66,13 +70,18 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
                     messageProcessedManager.setMessageIsProcessed(message);
                 }
             } else {
-                LOG.debug("PaymentTransactionStateChangedMessage {} has not the correct Trasaction state to be processed.", message.getId());
+                LOG.debug("PaymentTransactionStateChangedMessage {} has incorrect Transaction state to be processed.", message.getId());
                 messageProcessedManager.setMessageIsProcessed(message);
             }
         } else {
             LOG.error("There is no payment in commercetools platform with id {}.", message.getResource().getId());
             messageProcessedManager.setMessageIsProcessed(message);
         }
+
+        // we tried to do all possible jobs. If CartAndMessage is not returned above -
+        // don't try to process this message next time
+        timeStampManager.setActualProcessedMessageTimeStamp(message.getLastModifiedAt());
+
         return null;
     }
 

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -94,7 +94,8 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
     private void fetchUnprocessedMessagesFromPlatform() {
         final PagedQueryResult<Message> result = queryPlatform();
         result.getResults().stream()
-                .map(message -> message.as(PaymentTransactionStateChangedMessage.class))
+                .filter(message -> message instanceof PaymentTransactionStateChangedMessage)
+                .map(message -> (PaymentTransactionStateChangedMessage) message)
                 .forEach(message -> {
                     if (messageProcessedManager.isMessageUnprocessed(message)) {
                         unprocessedMessagesQueue.add(message);

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -94,8 +94,7 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
     private void fetchUnprocessedMessagesFromPlatform() {
         final PagedQueryResult<Message> result = queryPlatform();
         result.getResults().stream()
-                .filter(message -> message instanceof PaymentTransactionStateChangedMessage)
-                .map(message -> (PaymentTransactionStateChangedMessage) message)
+                .map(message -> message.as(PaymentTransactionStateChangedMessage.class))
                 .forEach(message -> {
                     if (messageProcessedManager.isMessageUnprocessed(message)) {
                         unprocessedMessagesQueue.add(message);

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -50,8 +50,8 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
     private boolean wasInitialQueried = false;
     private long total;
     private long offset = 0L;
-    private final int RESULTSPERPAGE = 500;
-    private final int PAGEOVERLAP = 5;
+    final int RESULTSPERPAGE = 500;
+    final int PAGEOVERLAP = 5;
 
     /**
      * @return the oldest unprocessed message from the queue, or <b>null</b> if no new messages to process in CTP.

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -50,8 +50,8 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
     private boolean wasInitialQueried = false;
     private long total;
     private long offset = 0L;
-    final int RESULTSPERPAGE = 500;
-    final int PAGEOVERLAP = 5;
+    final int RESULTS_PER_PAGE = 500;
+    final int PAGE_OVERLAP = 5;
 
     /**
      * @return the oldest unprocessed message from the queue, or <b>null</b> if no new messages to process in CTP.
@@ -117,7 +117,7 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
             LOG.debug("First Query returned {} results.", total);
         }
         //Due to nondeterministic ordering of messages with same timestamp we fetch next pages with overlap
-        offset = result.getOffset() + RESULTSPERPAGE - PAGEOVERLAP;
+        offset = result.getOffset() + RESULTS_PER_PAGE - PAGE_OVERLAP;
         wasInitialQueried = true;
         return result;
     }
@@ -130,7 +130,7 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
                 .withPredicates(m -> m.type().is(MESSAGETYPE))
                 .withSort(m -> m.lastModifiedAt().sort().asc())
                 .withOffset(offset)
-                .withLimit(RESULTSPERPAGE);
+                .withLimit(RESULTS_PER_PAGE);
 
         final ZonedDateTime timestamp = timeStampManager.getLastProcessedMessageTimeStamp();
 

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -13,10 +13,11 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 /**
  * Reads PaymentTransactionStateChangedMessages from the commercetools platform.
@@ -43,51 +44,72 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
     @Value("${ctp.messagereader.minutesoverlapping}")
     private Integer minutesOverlapping;
 
-    private List<PaymentTransactionStateChangedMessage> messages = Collections.emptyList();
+    @Nonnull
+    private Queue<PaymentTransactionStateChangedMessage> unprocessedMessagesQueue = new ArrayDeque<>();
+
     private boolean wasInitialQueried = false;
     private long total;
     private long offset = 0L;
     private final int RESULTSPERPAGE = 500;
     private final int PAGEOVERLAP = 5;
 
-    private MessageQuery messageQuery;
-
+    /**
+     * @return the oldest unprocessed message from the queue, or <b>null</b> if no new messages to process in CTP.
+     */
     @Override
+    @Nullable
     public PaymentTransactionStateChangedMessage read() {
         LOG.debug("wasInitialQueried: {}", wasInitialQueried);
-        if (isQueryNeeded()) {
-            getUnprocessedMessagesFromPlatform();
+
+        while (isQueryNeeded()) {
+            fetchUnprocessedMessagesFromPlatform();
         }
-        return getMessageFromList();
+
+        return getUnprocessedMessageFromQueue();
     }
 
-    private PaymentTransactionStateChangedMessage getMessageFromList() {
-        if (messages.isEmpty()) {
-            return null;
-        } else {
-            timeStampManager.setActualProcessedMessageTimeStamp(messages.get(0).getLastModifiedAt());
-            return messages.remove(0);
-        }
+    /**
+     * @return oldest unprocessed message from the queue if exists, or <b>null</b>
+     */
+    @Nullable
+    private PaymentTransactionStateChangedMessage getUnprocessedMessageFromQueue() {
+        return unprocessedMessagesQueue.poll();
     }
 
+    /**
+     * A first or next CTP query is needed if we don't have unprocessed messages in the queue.
+     *
+     * @return <b>true</b> if messages queue never fetched or {@code unprocessedMessagesQueue} is empty and CTP still
+     * has items to fetch (query next page).
+     */
     private boolean isQueryNeeded() {
-        return !wasInitialQueried || (messages.isEmpty() && total > offset);
+        return !wasInitialQueried || (unprocessedMessagesQueue.isEmpty() && total > offset);
     }
 
-    private void getUnprocessedMessagesFromPlatform() {
-        final List<Message> result = queryPlatform();
-        messages = result.stream()
+    /**
+     * Fetch messages from the platform and put all unprocessed messages to {@code unprocessedMessagesQueue}.
+     * Also, update {@link TimeStampManager#setActualProcessedMessageTimeStamp(java.time.ZonedDateTime)
+     * actualProcessedMessageTimeStamp} for processed messages.
+     */
+    private void fetchUnprocessedMessagesFromPlatform() {
+        final PagedQueryResult<Message> result = queryPlatform();
+        result.getResults().stream()
                 .map(message -> message.as(PaymentTransactionStateChangedMessage.class))
-                .filter(message -> messageProcessedManager.isMessageUnprocessed(message))
-                .collect(Collectors.toList());
+                .forEach(message -> {
+                    if (messageProcessedManager.isMessageUnprocessed(message)) {
+                        unprocessedMessagesQueue.add(message);
+                    } else {
+                        timeStampManager.setActualProcessedMessageTimeStamp(message.getLastModifiedAt());
+                    }
+                });
 
-        LOG.info("total {} messages, {} on current page, {} of them are are unprocessed", total, result.size(), messages.size());
+        LOG.info("fetched messages [{}-{}] of total {}, {} of them are are unprocessed",
+                result.getOffset() + 1, result.getOffset() + result.getCount(), result.getTotal(), unprocessedMessagesQueue.size());
     }
 
-
-    private List<Message> queryPlatform() {
+    private PagedQueryResult<Message> queryPlatform() {
         LOG.debug("Query CTP for Messages");
-        buildQuery();
+        final MessageQuery messageQuery = buildQuery();
         final PagedQueryResult<Message> result = client.executeBlocking(messageQuery);
         //Get the total workload from first Query
         if (!wasInitialQueried) {
@@ -97,21 +119,26 @@ public class MessageReader implements ItemReader<PaymentTransactionStateChangedM
         //Due to nondeterministic ordering of messages with same timestamp we fetch next pages with overlap
         offset = result.getOffset() + RESULTSPERPAGE - PAGEOVERLAP;
         wasInitialQueried = true;
-        return result.getResults();
+        return result;
     }
 
 
     //Due to eventual consistency messages could be created with a delay. Fetching several minutes prior last Timestamp
-    private void buildQuery() {
-        messageQuery = MessageQuery.of()
+    private MessageQuery buildQuery() {
+
+        MessageQuery messageQuery = MessageQuery.of()
                 .withPredicates(m -> m.type().is(MESSAGETYPE))
                 .withSort(m -> m.lastModifiedAt().sort().asc())
                 .withOffset(offset)
                 .withLimit(RESULTSPERPAGE);
+
         final ZonedDateTime timestamp = timeStampManager.getLastProcessedMessageTimeStamp();
+
         if (timestamp != null) {
             messageQuery = messageQuery.plusPredicates(
                     m -> m.lastModifiedAt().isGreaterThan(timestamp.minusMinutes(minutesOverlapping)));
         }
+
+        return messageQuery;
     }
 }

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManagerImpl.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManagerImpl.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Arrays;
 
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+
 public class PaymentCreationConfigurationManagerImpl implements PaymentCreationConfigurationManager {
 
     @Value("${createorder.createorderon}")
@@ -18,6 +20,6 @@ public class PaymentCreationConfigurationManagerImpl implements PaymentCreationC
         return TransactionState.SUCCESS.equals(message.getState())
                 && (payment.getTransactions().stream().anyMatch(
                 transaction -> transactionID.equals(transaction.getId())
-                        && Arrays.stream(transactionTypes).anyMatch(type -> type.equals(transaction.getType().toString()))));
+                        && Arrays.stream(transactionTypes).anyMatch(type -> equalsIgnoreCase(type, transaction.getType().toString()))));
     }
 }

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/MessageProcessorIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/MessageProcessorIntegrationTest.java
@@ -6,6 +6,7 @@ import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageFilter;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageReader;
 import com.commercetools.paymenttoorderprocessor.testconfiguration.BasicTestConfiguration;
 import com.commercetools.paymenttoorderprocessor.testconfiguration.ExtendedTestConfiguration;
+import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
 import com.commercetools.paymenttoorderprocessor.wrapper.CartAndMessage;
 import com.neovisionaries.i18n.CountryCode;
 import io.sphere.sdk.carts.Cart;
@@ -28,7 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
-import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -42,8 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {BasicTestConfiguration.class, ExtendedTestConfiguration.class,
         ShereClientConfiguration.class},
-        initializers = ConfigFileApplicationContextInitializer.class,
-        loader = SpringBootContextLoader.class)
+        initializers = ConfigFileApplicationContextInitializer.class)
 public class MessageProcessorIntegrationTest extends IntegrationTest {
 
     @Autowired
@@ -54,6 +53,9 @@ public class MessageProcessorIntegrationTest extends IntegrationTest {
 
     @Autowired
     private BlockingSphereClient testClient;
+
+    @Autowired
+    private TimeStampManager timeStampManager;
 
     @Test
     public void messageProcessorSuccess() throws Exception {
@@ -101,6 +103,10 @@ public class MessageProcessorIntegrationTest extends IntegrationTest {
             final Cart cartToTest = cartAndMessage.getCart();
             assertThat(cartToTest).isNotNull();
             assertThat(cartToTest.getId()).isEqualTo(cartWithPayment.getId());
+
+            // when MessageFilter.process() returns CartAndMessage instance - timestamp is not updated
+            timeStampManager.persistLastProcessedMessageTimeStamp();
+            assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isNotEqualTo(message[0].getLastModifiedAt());
 
             return paymentWithTransactionStateChange;
         });

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/MessageProcessorIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/MessageProcessorIntegrationTest.java
@@ -106,7 +106,7 @@ public class MessageProcessorIntegrationTest extends IntegrationTest {
 
             // when MessageFilter.process() returns CartAndMessage instance - timestamp is not updated
             timeStampManager.persistLastProcessedMessageTimeStamp();
-            assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isNotEqualTo(message[0].getLastModifiedAt());
+            assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isNull();
 
             return paymentWithTransactionStateChange;
         });

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilterTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilterTest.java
@@ -1,0 +1,92 @@
+package com.commercetools.paymenttoorderprocessor.jobs.actions;
+
+import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.ExtendedTestConfiguration;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.HttpClientMockConfiguration;
+import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
+import com.commercetools.paymenttoorderprocessor.wrapper.CartAndMessage;
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.json.SphereJsonUtils;
+import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+        classes = {
+                MessageFilterTest.TestConfig.class, HttpClientMockConfiguration.class, ExtendedTestConfiguration.class
+        },
+        initializers = ConfigFileApplicationContextInitializer.class)
+// clean messageProcessedManager on every test
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class MessageFilterTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public BlockingSphereClient client() {
+            return mock(BlockingSphereClient.class);
+        }
+    }
+
+    @Autowired
+    private MessageFilter messageProcessor;
+
+    @Autowired
+    private TimeStampManager timeStampManager;
+
+    @Autowired
+    private BlockingSphereClient client;
+
+    @Autowired
+    private MessageProcessedManager messageProcessedManager;
+
+    private PaymentTransactionStateChangedMessage testMessage;
+
+    @Before
+    public void setUp() {
+        testMessage = SphereJsonUtils.readObjectFromResource("mocks/messageFilter/PaymentTransactionStateChangedMessage.json", PaymentTransactionStateChangedMessage.class);
+    }
+
+    @Test
+    public void messageProcessor_withEmptyPayment_updatesLastProcessedMessageTimeStamp() {
+        assertThat(messageProcessedManager.isMessageUnprocessed(testMessage)).isTrue();
+        final CartAndMessage cartAndMessage = messageProcessor.process(testMessage);
+        assertThat(cartAndMessage).isNull();
+
+        // when MessageFilter.process() returns null - timestamp is updated
+        timeStampManager.persistLastProcessedMessageTimeStamp();
+        assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isEqualTo(testMessage.getLastModifiedAt());
+        assertThat(messageProcessedManager.isMessageUnprocessed(testMessage)).isFalse();
+    }
+
+    @Test
+    public void messageProcessor_withExistentPayment_updatesLastProcessedMessageTimeStamp() {
+        assertThat(messageProcessedManager.isMessageUnprocessed(testMessage)).isTrue();
+
+        // return some payment on request
+        when(client.executeBlocking(any())).thenReturn(mock(Payment.class));
+
+        final CartAndMessage cartAndMessage = messageProcessor.process(testMessage);
+        assertThat(cartAndMessage).isNull();
+
+        // when MessageFilter.process() returns null - timestamp is updated
+        timeStampManager.persistLastProcessedMessageTimeStamp();
+        assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isEqualTo(testMessage.getLastModifiedAt());
+        assertThat(messageProcessedManager.isMessageUnprocessed(testMessage)).isFalse();
+    }
+}

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReaderTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReaderTest.java
@@ -1,0 +1,129 @@
+package com.commercetools.paymenttoorderprocessor.jobs.actions;
+
+import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.ExtendedTestConfiguration;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.HttpClientMockConfiguration;
+import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.json.SphereJsonUtils;
+import io.sphere.sdk.messages.queries.MessageQuery;
+import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
+import io.sphere.sdk.queries.PagedQueryResult;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+        classes = {
+                MessageReaderTest.TestConfig.class, HttpClientMockConfiguration.class, ExtendedTestConfiguration.class
+        },
+        initializers = ConfigFileApplicationContextInitializer.class)
+// clean MessageReader and messageProcessedManager on every test
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class MessageReaderTest {
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public BlockingSphereClient client() {
+            return mock(BlockingSphereClient.class);
+        }
+    }
+
+    private static final String MOCKS = "mocks/messageReader/";
+
+    private static final TypeReference<PagedQueryResult<PaymentTransactionStateChangedMessage>> PagedQueryWithMessages =
+            new TypeReference<PagedQueryResult<PaymentTransactionStateChangedMessage>>() {
+            };
+
+    @Autowired
+    private MessageReader messageReader;
+
+    @Autowired
+    private TimeStampManager timeStampManager;
+
+    @Autowired
+    private MessageProcessedManager messageProcessedManager;
+
+    @Autowired
+    private BlockingSphereClient client;
+
+    @Test
+    public void read_whenEmpty_returnsNull() {
+        when(client.executeBlocking(any())).thenReturn(SphereJsonUtils.readObjectFromResource(MOCKS + "messagesResult_empty.json",
+                PagedQueryWithMessages));
+
+        assertThat(messageReader.read()).isNull();
+    }
+
+    @Test
+    public void read_whenOnePage_returnsResultFromThePage() {
+        when(client.executeBlocking(any())).thenReturn(SphereJsonUtils.readObjectFromResource(MOCKS + "messagesResult_1.json",
+                PagedQueryWithMessages));
+        PaymentTransactionStateChangedMessage firstUnprocessedMessage = messageReader.read();
+        assertThat(firstUnprocessedMessage).isNotNull();
+        assertThat(firstUnprocessedMessage.getId()).isEqualTo("11111111-1111-1111-1111-111111111111");
+
+        PaymentTransactionStateChangedMessage secondUnprocessedMessage = messageReader.read();
+        assertThat(secondUnprocessedMessage).isNotNull();
+        assertThat(secondUnprocessedMessage.getId()).isEqualTo("44444444-4444-4444-4444-444444444444");
+
+        // sphere client should be called only once even if we call messageReader.read twice,
+        // because both results are on the same page
+        verify(client, times(1)).executeBlocking(any());
+
+        // no messages processed - last timestamp is not updated
+        timeStampManager.persistLastProcessedMessageTimeStamp();
+        assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isNull();
+    }
+
+    @Test
+    public void read_whenFirstPageIsEmpty_returnsResultFromSecondPage_AndPersistsTimestamp() {
+        PagedQueryResult<PaymentTransactionStateChangedMessage> pagedFirstResult = SphereJsonUtils.readObjectFromResource(MOCKS + "messagesResult_1.json",
+                PagedQueryWithMessages);
+        PagedQueryResult<PaymentTransactionStateChangedMessage> pagedSecondResult = SphereJsonUtils.readObjectFromResource(MOCKS + "messagesResult_2.json",
+                PagedQueryWithMessages);
+        List<PaymentTransactionStateChangedMessage> firstResults = pagedFirstResult.getResults();
+        firstResults.forEach(messageProcessedManager::setMessageIsProcessed);
+
+        when(client.executeBlocking(any(MessageQuery.class))).thenAnswer(a -> {
+            MessageQuery query = a.getArgumentAt(0, MessageQuery.class);
+            if (query.offset() == 0) {
+                return pagedFirstResult;
+            } else {
+                return pagedSecondResult;
+            }
+        });
+
+        PaymentTransactionStateChangedMessage firstMessage = messageReader.read();
+        assertThat(firstMessage).isNotNull();
+        assertThat(firstMessage.getId()).isEqualTo("111");
+
+        PaymentTransactionStateChangedMessage secondMessage = messageReader.read();
+        assertThat(secondMessage).isNotNull();
+        assertThat(secondMessage.getId()).isEqualTo("444");
+
+        // sphere client called twice to fetch 2 pages
+        verify(client, times(2)).executeBlocking(any());
+
+        // verify last timestamp is equal to last processed message
+        PaymentTransactionStateChangedMessage lastResultOnFirstPage = firstResults.get(firstResults.size() - 1);
+        timeStampManager.persistLastProcessedMessageTimeStamp();
+        assertThat(timeStampManager.getLastProcessedMessageTimeStamp()).isEqualTo(lastResultOnFirstPage.getLastModifiedAt());
+    }
+}

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReaderTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReaderTest.java
@@ -170,7 +170,7 @@ public class MessageReaderTest {
             MessageQuery query = a.getArgumentAt(0, MessageQuery.class);
             if (query.offset() == 0) {
                 return firstMessagesResult;
-            } else if (query.offset() <= (messageReader.RESULTSPERPAGE - messageReader.PAGEOVERLAP)) {
+            } else if (query.offset() <= (messageReader.RESULTS_PER_PAGE - messageReader.PAGE_OVERLAP)) {
                 return secondMessagesResult;
             } else {
                 return emptyMessagesResult;

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/testconfiguration/ExtendedTestConfiguration.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/testconfiguration/ExtendedTestConfiguration.java
@@ -54,20 +54,23 @@ public class ExtendedTestConfiguration {
         };
     }
 
+    /**
+     * Simulate "processed" message status by message ID saving.
+     */
     @Bean
     public MessageProcessedManager messageProcessedManager() {
         return new MessageProcessedManager() {
 
-            private HashSet<Message> processedMessages = new HashSet<>();
+            private HashSet<String> processedMessages = new HashSet<>();
 
             @Override
             public void setMessageIsProcessed(Message message) {
-                processedMessages.add(message);
+                processedMessages.add(message.getId());
             }
 
             @Override
             public boolean isMessageUnprocessed(Message message) {
-                return !processedMessages.contains(message);
+                return !processedMessages.contains(message.getId());
             }
         };
     }

--- a/src/test/resources/mocks/messageFilter/PaymentTransactionStateChangedMessage.json
+++ b/src/test/resources/mocks/messageFilter/PaymentTransactionStateChangedMessage.json
@@ -1,0 +1,15 @@
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "version": 1,
+  "sequenceNumber": 9,
+  "resource": {
+    "typeId": "payment",
+    "id": "22222222-2222-2222-2222-222222222222"
+  },
+  "resourceVersion": 15,
+  "type": "PaymentTransactionStateChanged",
+  "transactionId": "33333333-3333-3333-3333-333333333333",
+  "state": "Success",
+  "createdAt": "2011-11-11T11:11:11.111Z",
+  "lastModifiedAt": "2011-11-11T22:22:22.222Z"
+}

--- a/src/test/resources/mocks/messageReader/messagesResult_1.json
+++ b/src/test/resources/mocks/messageReader/messagesResult_1.json
@@ -1,0 +1,38 @@
+{
+  "limit": 2,
+  "offset": 0,
+  "count": 2,
+  "total": 500,
+  "results": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "version": 1,
+      "sequenceNumber": 9,
+      "resource": {
+        "typeId": "payment",
+        "id": "22222222-2222-2222-2222-222222222222"
+      },
+      "resourceVersion": 15,
+      "type": "PaymentTransactionStateChanged",
+      "transactionId": "33333333-3333-3333-3333-333333333333",
+      "state": "Success",
+      "createdAt": "2018-04-05T00:00:00.000Z",
+      "lastModifiedAt": "2018-04-05T00:00:00.000Z"
+    },
+    {
+      "id": "44444444-4444-4444-4444-444444444444",
+      "version": 1,
+      "sequenceNumber": 6,
+      "resource": {
+        "typeId": "payment",
+        "id": "55555555-5555-5555-5555-555555555555"
+      },
+      "resourceVersion": 9,
+      "type": "PaymentTransactionStateChanged",
+      "transactionId": "66666666-6666-6666-6666-666666666666",
+      "state": "Pending",
+      "createdAt": "2018-04-05T01:00:00.000Z",
+      "lastModifiedAt": "2018-04-05T01:00:00.000Z"
+    }
+  ]
+}

--- a/src/test/resources/mocks/messageReader/messagesResult_2.json
+++ b/src/test/resources/mocks/messageReader/messagesResult_2.json
@@ -1,0 +1,38 @@
+{
+  "limit": 2,
+  "offset": 0,
+  "count": 2,
+  "total": 500,
+  "results": [
+    {
+      "id": "111",
+      "version": 1,
+      "sequenceNumber": 9,
+      "resource": {
+        "typeId": "payment",
+        "id": "222"
+      },
+      "resourceVersion": 15,
+      "type": "PaymentTransactionStateChanged",
+      "transactionId": "333",
+      "state": "Success",
+      "createdAt": "2018-04-06T00:00:00.000Z",
+      "lastModifiedAt": "2018-04-06T00:00:00.000Z"
+    },
+    {
+      "id": "444",
+      "version": 1,
+      "sequenceNumber": 6,
+      "resource": {
+        "typeId": "payment",
+        "id": "555"
+      },
+      "resourceVersion": 9,
+      "type": "PaymentTransactionStateChanged",
+      "transactionId": "555",
+      "state": "Pending",
+      "createdAt": "2018-04-06T14:59:38.127Z",
+      "lastModifiedAt": "2018-04-06T14:59:38.127Z"
+    }
+  ]
+}

--- a/src/test/resources/mocks/messageReader/messagesResult_2.json
+++ b/src/test/resources/mocks/messageReader/messagesResult_2.json
@@ -1,6 +1,6 @@
 {
   "limit": 2,
-  "offset": 0,
+  "offset": 2,
   "count": 2,
   "total": 500,
   "results": [
@@ -16,8 +16,8 @@
       "type": "PaymentTransactionStateChanged",
       "transactionId": "333",
       "state": "Success",
-      "createdAt": "2018-04-06T00:00:00.000Z",
-      "lastModifiedAt": "2018-04-06T00:00:00.000Z"
+      "createdAt": "2018-04-06T12:34:56.789Z",
+      "lastModifiedAt": "2018-04-06T12:34:56.789Z"
     },
     {
       "id": "444",
@@ -31,8 +31,8 @@
       "type": "PaymentTransactionStateChanged",
       "transactionId": "555",
       "state": "Pending",
-      "createdAt": "2018-04-06T14:59:38.127Z",
-      "lastModifiedAt": "2018-04-06T14:59:38.127Z"
+      "createdAt": "2018-04-07T22:22:22.222Z",
+      "lastModifiedAt": "2018-04-07T22:22:22.222Z"
     }
   ]
 }

--- a/src/test/resources/mocks/messageReader/messagesResult_empty.json
+++ b/src/test/resources/mocks/messageReader/messagesResult_empty.json
@@ -1,0 +1,7 @@
+{
+  "limit": 20,
+  "offset": 0,
+  "count": 0,
+  "total": 0,
+  "results": []
+}

--- a/src/test/resources/mocks/messageReader/messagesResult_empty.json
+++ b/src/test/resources/mocks/messageReader/messagesResult_empty.json
@@ -1,6 +1,6 @@
 {
   "limit": 20,
-  "offset": 0,
+  "offset": 500,
   "count": 0,
   "total": 0,
   "results": []


### PR DESCRIPTION
Urgent fix of issue #26

  - [update last timestamp on every processed message in the `MessageProcessor` implementation](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-42bcb010de4d32de77dbed7044ee7884R81), so the next service run will skip already processed messages
  - in [`MessageReader`](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-43e3e2ea57f79fa2f8eb7a25f93dd4d0):
    - [use Queue instead of List](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-43e3e2ea57f79fa2f8eb7a25f93dd4d0R47) (just because it is a messages queue ;) ). This allows to [use properly next message fetching](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-43e3e2ea57f79fa2f8eb7a25f93dd4d0L64)
    - **major change**: [fetch pages until we have results](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-43e3e2ea57f79fa2f8eb7a25f93dd4d0R64) (i.e. replace `if` by `while`)
    - for every fetched message: [if it is processed - update timestamp to avoid fetching it next time](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-43e3e2ea57f79fa2f8eb7a25f93dd4d0R102)

  - tests for [`MessageReader`](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-a09c4e53473f6218bd3a71b84368cefa) and [`MessageProcessor`](https://github.com/commercetools/commercetools-payment-to-order-processor/pull/27/files#diff-b496bb93bfab150d9cc4b30b40ba9fad) with respective mock result resources (JSON files)
