### PR TITLE
Don't shorten stack trace.

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -31,12 +31,6 @@ As such, enabling logback status data is very highly recommended and should be c
                 <stackTrace>
                     <!-- Map default "stack_trace" to "stackTrace" -->
                     <fieldName>stackTrace</fieldName>
-                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-                        <maxDepthPerThrowable>30</maxDepthPerThrowable>
-                        <maxLength>2048</maxLength>
-                        <shortenedClassNameLength>20</shortenedClassNameLength>
-                        <rootCauseFirst>true</rootCauseFirst>
-                    </throwableConverter>
                 </stackTrace>
             </providers>
         </encoder>


### PR DESCRIPTION
don't shorten stack trace on error logs.