### PR TITLE
Add implementation for processing PaymentTransactionAdded messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ export CREATEORDER_ENDPOINT_URL=https://localhost/createOrder
 * the time overlap prior to lastproccessed timestamp -> to eliminate problems at edge cases
 * the container for the custom object (saving the timestamp)
 * basic HTTP authentication for create order API endpoint
+* if true, messages with type `PaymentTransactionAdded` will be processed (default: `true`)
+* if true, messages with type `PaymentTransactionStateChanged` will be processed (default: `true`)
 
 Example part of a shell script:
 ```
@@ -90,6 +92,8 @@ export CTP_TIMEOUT=30000
 export CTP_MESSAGEREADER_MINUTESOVERLAPPING=2
 export CTP_CUSTOM_OBJECT_CONTAINERNAME=commercetools-payment-to-order-processor
 export CREATEORDER_ENDPOINT_AUTHENTICATION=<username>:<password>
+export CTP_MESSAGES_PROCESSTRANSACTIONADDEDMESSAGES=true
+export CTP_MESSAGES_PROCESSTRANSACTIONSTATECHANGEDMESSAGES=true
 ```
 
 # Build and release

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## Goal of the service
 In general orders are created from carts by the frontend. For redirect payments like Credit card 3D Secure, Paypal or Sofortüberweisung shop front end is confronted with an issue that in some cases there is a valid payment but no order as user did not reach front end's success URL, which creates an order from current cart. One of the use cases would be lost internet connection or accidentally closed tab after successfully issued payment. Scheduled processor ensures that for every successful payment and valid cart an order can be still asynchronously created. More details on the process can be found [here](https://github.com/commercetools/commercetools-payment-to-order-processor/blob/master/doc/REQUIREMENTS.MD)
 
-The service polls `PaymentTransactionStateChanged` messages from the commercetools platform since the `lastProcessedMessageTimeStamp` stored in a custom object in the platform.
+The service polls `PaymentTransactionStateChanged` and `PaymentTransactionAdded` messages from the commercetools platform since the `lastProcessedMessageTimeStamp` stored in a custom object in the platform.
 If the PaymentTransaction type matches the configured values and the total price of the cart equals the amount of the transaction and is not already ordered then the service has to trigger order creation.
 
 ## Creating the order

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.commercetools.payment-to-order-processor</groupId>
     <artifactId>payment-to-order-processor</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/PaymentToOrderApplication.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/PaymentToOrderApplication.java
@@ -17,8 +17,7 @@ import org.springframework.context.annotation.DependsOn;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
-@SpringBootApplication
-@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class PaymentToOrderApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/dto/PaymentTransactionCreatedOrUpdatedMessage.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/dto/PaymentTransactionCreatedOrUpdatedMessage.java
@@ -1,0 +1,67 @@
+package com.commercetools.paymenttoorderprocessor.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.sphere.sdk.messages.GenericMessageImpl;
+import io.sphere.sdk.messages.MessageDerivateHint;
+import io.sphere.sdk.messages.UserProvidedIdentifiers;
+import io.sphere.sdk.payments.Payment;
+import io.sphere.sdk.payments.Transaction;
+import io.sphere.sdk.payments.TransactionState;
+
+import java.time.ZonedDateTime;
+
+@JsonDeserialize(
+        as = PaymentTransactionCreatedOrUpdatedMessage.class
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaymentTransactionCreatedOrUpdatedMessage extends GenericMessageImpl<Payment> {
+    public static final String MESSAGE_TYPE = "PaymentTransactionCreatedOrUpdatedMessage";
+    public static final MessageDerivateHint<PaymentTransactionCreatedOrUpdatedMessage> MESSAGE_HINT
+            = MessageDerivateHint.ofSingleMessageType("PaymentTransactionCreatedOrUpdatedMessage", PaymentTransactionCreatedOrUpdatedMessage.class, Payment.referenceTypeId());
+    private final TransactionState state;
+    private final String transactionId;
+    private final Transaction transaction;
+
+    @JsonCreator()
+    private PaymentTransactionCreatedOrUpdatedMessage(@JsonProperty("id") final String id,
+                                                      @JsonProperty("version") final Long version,
+                                                      @JsonProperty("createdAt") final ZonedDateTime createdAt,
+                                                      @JsonProperty("lastModifiedAt") final ZonedDateTime lastModifiedAt,
+                                                      @JsonProperty("resource") final JsonNode resource,
+                                                      @JsonProperty("sequenceNumber") final Long sequenceNumber,
+                                                      @JsonProperty("resourceVersion") final Long resourceVersion,
+                                                      @JsonProperty("type") final String type,
+                                                      @JsonProperty("resourceUserProvidedIdentifiers") final UserProvidedIdentifiers resourceUserProvidedIdentifiers,
+                                                      @JsonProperty("state") final TransactionState state,
+                                                      @JsonProperty("transactionId") final String transactionId,
+                                                      @JsonProperty("transaction") final Transaction transaction) {
+        super(id, version, createdAt, lastModifiedAt, resource, sequenceNumber, resourceVersion, type, resourceUserProvidedIdentifiers, Payment.class);
+        this.state = state;
+        this.transactionId = transactionId;
+        this.transaction = transaction;
+    }
+
+    public TransactionState getState() {
+        Transaction transaction = this.getTransaction();
+        if (transaction != null) {
+            return transaction.getState();
+        }
+        return this.state;
+    }
+
+    public String getTransactionId() {
+        Transaction transaction = this.getTransaction();
+        if (transaction != null) {
+            return transaction.getId();
+        }
+        return this.transactionId;
+    }
+
+    public Transaction getTransaction() {
+        return transaction;
+    }
+}

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/dto/PaymentTransactionCreatedOrUpdatedMessage.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/dto/PaymentTransactionCreatedOrUpdatedMessage.java
@@ -19,9 +19,6 @@ import java.time.ZonedDateTime;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaymentTransactionCreatedOrUpdatedMessage extends GenericMessageImpl<Payment> {
-    public static final String MESSAGE_TYPE = "PaymentTransactionCreatedOrUpdatedMessage";
-    public static final MessageDerivateHint<PaymentTransactionCreatedOrUpdatedMessage> MESSAGE_HINT
-            = MessageDerivateHint.ofSingleMessageType("PaymentTransactionCreatedOrUpdatedMessage", PaymentTransactionCreatedOrUpdatedMessage.class, Payment.referenceTypeId());
     private final TransactionState state;
     private final String transactionId;
     private final Transaction transaction;

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/ReadMessagesJob.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/ReadMessagesJob.java
@@ -2,6 +2,7 @@ package com.commercetools.paymenttoorderprocessor.jobs;
 
 import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
 import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManagerImpl;
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageFilter;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageReader;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.OrderCreator;
@@ -10,7 +11,6 @@ import com.commercetools.paymenttoorderprocessor.paymentcreationconfigurationman
 import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
 import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManagerImpl;
 import com.commercetools.paymenttoorderprocessor.wrapper.CartAndMessage;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.Step;
@@ -46,13 +46,13 @@ public class ReadMessagesJob {
 
     @Bean
     @DependsOn({"blockingSphereClient", "timeStampManager", "messageProcessedManager"})
-    public ItemReader<PaymentTransactionStateChangedMessage> reader() {
+    public ItemReader<PaymentTransactionCreatedOrUpdatedMessage> reader() {
         return new MessageReader();
     }
 
     @Bean
     @DependsOn({"blockingSphereClient", "paymentCreationConfigurationManager", "messageProcessedManager"})
-    public ItemProcessor<PaymentTransactionStateChangedMessage, CartAndMessage> processor() {
+    public ItemProcessor<PaymentTransactionCreatedOrUpdatedMessage, CartAndMessage> processor() {
         return new MessageFilter();
     }
 
@@ -91,11 +91,11 @@ public class ReadMessagesJob {
     }
 
     @Bean
-    public Step loadMessages(ItemReader<PaymentTransactionStateChangedMessage> reader,
-                             ItemProcessor<PaymentTransactionStateChangedMessage, CartAndMessage> processor,
+    public Step loadMessages(ItemReader<PaymentTransactionCreatedOrUpdatedMessage> reader,
+                             ItemProcessor<PaymentTransactionCreatedOrUpdatedMessage, CartAndMessage> processor,
                              ItemWriter<CartAndMessage> writer) {
         return steps.get(STEP_LOAD_MESSAGES)
-                .<PaymentTransactionStateChangedMessage, CartAndMessage>chunk(1)
+                .<PaymentTransactionCreatedOrUpdatedMessage, CartAndMessage>chunk(1)
                 .reader(reader)
                 .processor(processor)
                 .writer(writer)

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
@@ -48,7 +48,7 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionCreatedOrU
         LOG.debug("Called MessageFilter.process with parameter {}", message);
         final Payment payment = getCorrespondingPayment(message);
         if (payment != null) {
-            if (paymentCreationConfigurationManager.doesTransactionStateMatchConfiguration(message, payment)) {
+            if (paymentCreationConfigurationManager.isTransactionSuccessAndHasMatchingTransactionTypes(message, payment)) {
                 final Optional<Cart> oCart = getCorrespondingCart(payment);
                 if (oCart.isPresent()) {
                     final Cart cart = oCart.get();

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilter.java
@@ -1,6 +1,7 @@
 package com.commercetools.paymenttoorderprocessor.jobs.actions;
 
 import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import com.commercetools.paymenttoorderprocessor.paymentcreationconfigurationmanager.PaymentCreationConfigurationManager;
 import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
 import com.commercetools.paymenttoorderprocessor.wrapper.CartAndMessage;
@@ -10,7 +11,6 @@ import io.sphere.sdk.carts.queries.CartQuery;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.Transaction;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 import io.sphere.sdk.payments.queries.PaymentByIdGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.Optional;
 
 /***
- * Checks if PaymentTransactionStateChangedMessage and corresponding Cart is viable for creation of an Order
+ * Checks if PaymentTransactionCreatedOrUpdatedMessage and corresponding Cart is viable for creation of an Order
  * @author mht@dotsource.de
  *
  */
-public class MessageFilter implements ItemProcessor<PaymentTransactionStateChangedMessage, CartAndMessage> {
+public class MessageFilter implements ItemProcessor<PaymentTransactionCreatedOrUpdatedMessage, CartAndMessage> {
     private static final Logger LOG = LoggerFactory.getLogger(MessageFilter.class);
 
     @Autowired
@@ -44,7 +44,7 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
     private TimeStampManager timeStampManager;
 
     @Override
-    public CartAndMessage process(PaymentTransactionStateChangedMessage message) {
+    public CartAndMessage process(PaymentTransactionCreatedOrUpdatedMessage message) {
         LOG.debug("Called MessageFilter.process with parameter {}", message);
         final Payment payment = getCorrespondingPayment(message);
         if (payment != null) {
@@ -70,7 +70,7 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
                     messageProcessedManager.setMessageIsProcessed(message);
                 }
             } else {
-                LOG.debug("PaymentTransactionStateChangedMessage {} has incorrect transaction state to be processed.", message.getId());
+                LOG.debug("PaymentTransactionCreatedOrUpdatedMessage {} has incorrect transaction state to be processed.", message.getId());
                 messageProcessedManager.setMessageIsProcessed(message);
             }
         } else {
@@ -86,7 +86,7 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
     }
 
 
-    private boolean isCartAmountEqualToTransaction(Cart cart, final Payment payment, PaymentTransactionStateChangedMessage message) {
+    private boolean isCartAmountEqualToTransaction(Cart cart, final Payment payment, PaymentTransactionCreatedOrUpdatedMessage message) {
         final MonetaryAmount cartAmount = cart.getTotalPrice();
         final Optional<Transaction> transaction = payment
                 .getTransactions().stream().filter(t -> t.getId().equals(message.getTransactionId())).findFirst();
@@ -107,7 +107,7 @@ public class MessageFilter implements ItemProcessor<PaymentTransactionStateChang
     }
 
     @Nullable
-    private Payment getCorrespondingPayment(final PaymentTransactionStateChangedMessage message) {
+    private Payment getCorrespondingPayment(final PaymentTransactionCreatedOrUpdatedMessage message) {
         final String paymentId = message.getResource().getId();
         LOG.debug("Query CTP for Payment with ID {}", paymentId);
         final PaymentByIdGet paymentByIdGet = PaymentByIdGet.of(paymentId);

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -135,20 +135,6 @@ public class MessageReader implements ItemReader<PaymentTransactionCreatedOrUpda
     private MessageQuery buildQuery() {
 
         MessageQuery messageQuery = MessageQuery.of()
-                .plusPredicates(m -> {
-                    QueryPredicate<Message> predicate = null;
-                    if (processPaymentTransactionAddedMessages) {
-                        predicate = m.type().is(PAYMENT_TRANSACTION_ADDED);
-                    }
-                    if (processPaymentTransactionStateChangedMessages) {
-                        if (predicate != null) {
-                            predicate = predicate.or(m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED));
-                        } else {
-                            predicate = m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED);
-                        }
-                    }
-                    return predicate;
-                })
                 .withSort(m -> m.lastModifiedAt().sort().asc())
                 .withOffset(offset)
                 .withLimit(RESULTS_PER_PAGE);
@@ -159,6 +145,21 @@ public class MessageReader implements ItemReader<PaymentTransactionCreatedOrUpda
             messageQuery = messageQuery.plusPredicates(
                     m -> m.lastModifiedAt().isGreaterThan(timestamp.minusMinutes(minutesOverlapping)));
         }
+
+        messageQuery = messageQuery.plusPredicates(m -> {
+            QueryPredicate<Message> predicate = null;
+            if (processPaymentTransactionAddedMessages) {
+                predicate = m.type().is(PAYMENT_TRANSACTION_ADDED);
+            }
+            if (processPaymentTransactionStateChangedMessages) {
+                if (predicate != null) {
+                    predicate = predicate.or(m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED));
+                } else {
+                    predicate = m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED);
+                }
+            }
+            return predicate;
+        });
 
         return messageQuery;
     }

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -17,6 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.ZonedDateTime;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Queue;
 
 /**
@@ -128,7 +129,7 @@ public class MessageReader implements ItemReader<PaymentTransactionCreatedOrUpda
     private MessageQuery buildQuery() {
 
         MessageQuery messageQuery = MessageQuery.of()
-                .plusPredicates(m -> m.type().is(PAYMENT_TRANSACTION_ADDED).or(m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED)))
+                .plusPredicates(m -> m.type().isIn(Arrays.asList(PAYMENT_TRANSACTION_ADDED, PAYMENT_TRANSACTION_STATE_CHANGED)))
                 .withSort(m -> m.lastModifiedAt().sort().asc())
                 .withOffset(offset)
                 .withLimit(RESULTS_PER_PAGE);

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageReader.java
@@ -136,18 +136,18 @@ public class MessageReader implements ItemReader<PaymentTransactionCreatedOrUpda
 
         MessageQuery messageQuery = MessageQuery.of()
                 .plusPredicates(m -> {
-                    QueryPredicate<Message> query = null;
+                    QueryPredicate<Message> predicate = null;
                     if (processPaymentTransactionAddedMessages) {
-                        query = m.type().is(PAYMENT_TRANSACTION_ADDED);
+                        predicate = m.type().is(PAYMENT_TRANSACTION_ADDED);
                     }
                     if (processPaymentTransactionStateChangedMessages) {
-                        if (query != null) {
-                            query = query.or(m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED));
+                        if (predicate != null) {
+                            predicate = predicate.or(m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED));
                         } else {
-                            query = m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED);
+                            predicate = m.type().is(PAYMENT_TRANSACTION_STATE_CHANGED);
                         }
                     }
-                    return query;
+                    return predicate;
                 })
                 .withSort(m -> m.lastModifiedAt().sort().asc())
                 .withOffset(offset)

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManager.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManager.java
@@ -4,5 +4,5 @@ import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOr
 import io.sphere.sdk.payments.Payment;
 
 public interface PaymentCreationConfigurationManager {
-    boolean doesTransactionStateMatchConfiguration(PaymentTransactionCreatedOrUpdatedMessage message, Payment payment);
+    boolean isTransactionSuccessAndHasMatchingTransactionTypes(PaymentTransactionCreatedOrUpdatedMessage message, Payment payment);
 }

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManager.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManager.java
@@ -1,8 +1,8 @@
 package com.commercetools.paymenttoorderprocessor.paymentcreationconfigurationmanager;
 
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import io.sphere.sdk.payments.Payment;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 
 public interface PaymentCreationConfigurationManager {
-    boolean doesTransactionStateMatchConfiguration(PaymentTransactionStateChangedMessage message, Payment payment);
+    boolean doesTransactionStateMatchConfiguration(PaymentTransactionCreatedOrUpdatedMessage message, Payment payment);
 }

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManagerImpl.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManagerImpl.java
@@ -15,7 +15,7 @@ public class PaymentCreationConfigurationManagerImpl implements PaymentCreationC
     private String[] transactionTypes;
 
     @Override
-    public boolean doesTransactionStateMatchConfiguration(final PaymentTransactionCreatedOrUpdatedMessage message, final Payment payment) {
+    public boolean isTransactionSuccessAndHasMatchingTransactionTypes(final PaymentTransactionCreatedOrUpdatedMessage message, final Payment payment) {
         final String transactionID = message.getTransactionId();
         final TransactionState stateFromMessage = message.getState();
         return TransactionState.SUCCESS.equals(stateFromMessage)

--- a/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManagerImpl.java
+++ b/src/main/java/com/commercetools/paymenttoorderprocessor/paymentcreationconfigurationmanager/PaymentCreationConfigurationManagerImpl.java
@@ -1,8 +1,8 @@
 package com.commercetools.paymenttoorderprocessor.paymentcreationconfigurationmanager;
 
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.TransactionState;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Arrays;
@@ -15,9 +15,10 @@ public class PaymentCreationConfigurationManagerImpl implements PaymentCreationC
     private String[] transactionTypes;
 
     @Override
-    public boolean doesTransactionStateMatchConfiguration(final PaymentTransactionStateChangedMessage message, final Payment payment) {
+    public boolean doesTransactionStateMatchConfiguration(final PaymentTransactionCreatedOrUpdatedMessage message, final Payment payment) {
         final String transactionID = message.getTransactionId();
-        return TransactionState.SUCCESS.equals(message.getState())
+        final TransactionState stateFromMessage = message.getState();
+        return TransactionState.SUCCESS.equals(stateFromMessage)
                 && (payment.getTransactions().stream().anyMatch(
                 transaction -> transactionID.equals(transaction.getId())
                         && Arrays.stream(transactionTypes).anyMatch(type -> equalsIgnoreCase(type, transaction.getType().toString()))));

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/MessageReaderIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/MessageReaderIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.commercetools.paymenttoorderprocessor;
 
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import com.commercetools.paymenttoorderprocessor.fixtures.PaymentFixtures;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageReader;
 import com.commercetools.paymenttoorderprocessor.testconfiguration.BasicTestConfiguration;
@@ -9,7 +10,6 @@ import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +50,7 @@ public class MessageReaderIntegrationTest extends IntegrationTest {
     public void messageReaderIntegrationTest() throws Exception {
         PaymentFixtures.withPayment(testClient, payment-> {
 
-            //Preconditions create message in commercetoolsplatform:
+            //Preconditions create message in commercetools platform:
             final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).state(TransactionState.INITIAL).build();
             final AddTransaction addTransaction = AddTransaction.of(transactionDraft);
             final Payment paymentWithTransaction = testClient.executeBlocking(PaymentUpdateCommand.of(payment, addTransaction));
@@ -67,7 +67,7 @@ public class MessageReaderIntegrationTest extends IntegrationTest {
             }
             //Check if the message will be read:
             assertEventually(() -> {
-                PaymentTransactionStateChangedMessage message = messageReader.read();
+                PaymentTransactionCreatedOrUpdatedMessage message = messageReader.read();
                 assertThat(message).isNotNull();
                 assertThat(message.getResource().getId()).isEqualTo(payment.getId());
                 assertThat(message.getState()).isEqualTo(TransactionState.SUCCESS);

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/ReadMessagesJobIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/ReadMessagesJobIntegrationTest.java
@@ -1,0 +1,163 @@
+package com.commercetools.paymenttoorderprocessor;
+
+import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
+import com.commercetools.paymenttoorderprocessor.fixtures.CartFixtures;
+import com.commercetools.paymenttoorderprocessor.fixtures.PaymentFixtures;
+import com.commercetools.paymenttoorderprocessor.jobs.ReadMessagesJob;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.BasicTestConfiguration;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.ExtendedTestConfiguration;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.HttpClientMock;
+import com.commercetools.paymenttoorderprocessor.testconfiguration.HttpClientMockConfiguration;
+import com.neovisionaries.i18n.CountryCode;
+import io.sphere.sdk.carts.Cart;
+import io.sphere.sdk.carts.CartDraft;
+import io.sphere.sdk.carts.CustomLineItemDraft;
+import io.sphere.sdk.carts.commands.CartDeleteCommand;
+import io.sphere.sdk.carts.commands.CartUpdateCommand;
+import io.sphere.sdk.carts.commands.updateactions.AddPayment;
+import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.http.HttpStatusCode;
+import io.sphere.sdk.messages.Message;
+import io.sphere.sdk.messages.queries.MessageQuery;
+import io.sphere.sdk.models.Address;
+import io.sphere.sdk.models.LocalizedString;
+import io.sphere.sdk.payments.*;
+import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
+import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
+import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
+import io.sphere.sdk.projects.Project;
+import io.sphere.sdk.projects.queries.ProjectGet;
+import io.sphere.sdk.queries.PagedQueryResult;
+import io.sphere.sdk.taxcategories.TaxCategory;
+import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
+import org.assertj.core.api.Fail;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootContextLoader;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.commercetools.paymenttoorderprocessor.fixtures.PaymentFixtures.EUR;
+import static com.commercetools.paymenttoorderprocessor.fixtures.PaymentFixtures.EUR_20;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ReadMessagesJob.class, BasicTestConfiguration.class, ExtendedTestConfiguration.class,
+        ShereClientConfiguration.class, MessageReaderIntegrationTest.ContextConfiguration.class,
+        HttpClientMockConfiguration.class},
+        initializers = ConfigFileApplicationContextInitializer.class,
+        loader = SpringBootContextLoader.class)
+public class ReadMessagesJobIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private BlockingSphereClient testClient;
+
+    @Autowired
+    private Job job;
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private HttpClientMock httpClientMock;
+
+    @Autowired
+    private MessageProcessedManager messageProcessedManager;
+
+    @Value("${ctp.custom.object.containername}")
+    private String customObjectContainerName;
+
+    @Test
+    public void readAndProcessMessagesJobIntegrationTest() throws Exception {
+        PaymentFixtures.withPayments(2, testClient, payments -> {
+            // Prepare:
+            ZonedDateTime now = ZonedDateTime.now();
+
+            final List<TaxCategory> results = checkPreconditions();
+
+            httpClientMock.spyStatusCode(HttpStatusCode.OK_200);
+
+            Payment payment = payments.get(0);
+            final CustomLineItemDraft customLineItemDraft = CustomLineItemDraft.of(LocalizedString.ofEnglish("messageProcessorIntegrationTestCustomLineItem"), "Slug", EUR_20, results.get(0), 1L);
+            final Address address = Address.of(CountryCode.DE);
+            final Cart cart = CartFixtures.createCart(testClient, CartDraft.of(EUR)
+                    .withCustomLineItems(Collections.singletonList(customLineItemDraft))
+                    .withShippingAddress(address));
+            final Cart cartUpdated = testClient.executeBlocking(CartUpdateCommand.of(cart, AddPayment.of(payment)));
+
+            final TransactionDraft transactionDraft = TransactionDraftBuilder.of(TransactionType.AUTHORIZATION, EUR_20).state(TransactionState.INITIAL).build();
+            final AddTransaction addTransaction = AddTransaction.of(transactionDraft);
+            final Payment paymentWithTransaction = testClient.executeBlocking(PaymentUpdateCommand.of(payment, addTransaction));
+
+            final Transaction transaction = paymentWithTransaction.getTransactions().get(0);
+            final ChangeTransactionState changeTransactionState = ChangeTransactionState.of(TransactionState.SUCCESS, transaction.getId());
+            final Payment paymentWithTransactionStateChange = testClient.executeBlocking(PaymentUpdateCommand.of(paymentWithTransaction, changeTransactionState));
+
+            Payment payment2 = payments.get(1);
+
+            final Cart cart2 = CartFixtures.createCart(testClient, CartDraft.of(EUR)
+                    .withCustomLineItems(Collections.singletonList(customLineItemDraft))
+                    .withShippingAddress(address));
+            final Cart cart2Updated = testClient.executeBlocking(CartUpdateCommand.of(cart2, AddPayment.of(payment2)));
+
+            final TransactionDraft transactionDraft2 = TransactionDraftBuilder.of(TransactionType.CHARGE, EUR_20).state(TransactionState.SUCCESS).build();
+            final AddTransaction addTransaction2 = AddTransaction.of(transactionDraft2);
+            final Payment payment2WithTransactionAdded =  testClient.executeBlocking(PaymentUpdateCommand.of(payment2, addTransaction2));
+
+            // Test:
+            try {
+                //Give Platform time to create messages
+                Thread.sleep(10000L);
+                jobLauncher.run(job, new JobParameters());
+            } catch (Exception e) {
+                Fail.fail("Unexpected exception when testing", e);
+            }
+
+            // Assert:
+            List<Message> messages = fetchMessagesFrom(now);
+            for (Message message : messages) {
+                assertThat(messageProcessedManager.isMessageUnprocessed(message)).isFalse();
+            }
+
+            // Clean up:
+            deleteCarts(Arrays.asList(cartUpdated, cart2Updated));
+            return Arrays.asList(paymentWithTransactionStateChange, payment2WithTransactionAdded);
+        });
+    }
+
+    private void deleteCarts(List<Cart> carts) {
+        for (Cart cart : carts) {
+            testClient.executeBlocking(CartDeleteCommand.of(cart));
+        }
+    }
+
+    private List<Message> fetchMessagesFrom(ZonedDateTime now) {
+        MessageQuery messageQuery = MessageQuery.of()
+                .plusPredicates(m -> m.type().is("PaymentTransactionAdded").or(m.type().is("PaymentTransactionStateChanged")))
+                .plusPredicates(m -> m.lastModifiedAt().isGreaterThan(now));
+        PagedQueryResult<Message> messagePagedQueryResult = testClient.executeBlocking(messageQuery);
+        return messagePagedQueryResult.getResults();
+    }
+
+    private List<TaxCategory> checkPreconditions() {
+        final Project project = testClient.executeBlocking(ProjectGet.of());
+        final Boolean isMessageEnabled = project.getMessages().isEnabled();
+        assertThat(isMessageEnabled).as("Project should have messages enabled.").isTrue();
+        final PagedQueryResult<TaxCategory> result = testClient.executeBlocking(TaxCategoryQuery.of().byName("standard"));
+        final List<TaxCategory> results = result.getResults();
+        assertThat(results).isNotEmpty();
+        return results;
+    }
+}

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/fixtures/PaymentFixtures.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/fixtures/PaymentFixtures.java
@@ -1,18 +1,31 @@
 package com.commercetools.paymenttoorderprocessor.fixtures;
 
+import com.commercetools.paymenttoorderprocessor.jobs.JobListener;
 import io.sphere.sdk.client.BlockingSphereClient;
+import io.sphere.sdk.client.ConcurrentModificationException;
+import io.sphere.sdk.models.Versioned;
+import io.sphere.sdk.models.errors.ConcurrentModificationError;
 import io.sphere.sdk.payments.Payment;
 import io.sphere.sdk.payments.PaymentDraft;
 import io.sphere.sdk.payments.PaymentDraftBuilder;
 import io.sphere.sdk.payments.commands.PaymentCreateCommand;
+import io.sphere.sdk.payments.commands.PaymentDeleteCommand;
 import io.sphere.sdk.utils.MoneyImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class PaymentFixtures {
+    public static final Logger LOG = LoggerFactory.getLogger(JobListener.class);
+
     public static final CurrencyUnit EUR = Monetary.getCurrency("EUR");
     public static final CurrencyUnit USD = Monetary.getCurrency("USD");
     public static final CurrencyUnit UAH = Monetary.getCurrency("UAH");
@@ -21,17 +34,52 @@ public class PaymentFixtures {
     public static final MonetaryAmount USD_30 = MoneyImpl.of(30, USD);
     public static final MonetaryAmount UAH_42 = MoneyImpl.of(42, UAH);
 
-    public static Payment withPayment(final BlockingSphereClient client,
-                                   final UnaryOperator<PaymentDraftBuilder> builderMapping,
-                                   final UnaryOperator<Payment> op) {
-        final PaymentDraft paymentDraft = builderMapping.apply(PaymentDraftBuilder.of(EUR_20)).build();
-        final Payment payment = client.executeBlocking(PaymentCreateCommand.of(paymentDraft));
-        final Payment paymentToDelete = op.apply(payment);
+    public static void withPayment(final BlockingSphereClient client,
+                                      final UnaryOperator<PaymentDraftBuilder> builderMapping,
+                                      final UnaryOperator<Payment> op) {
+        withPayments(1, client, builderMapping, payments -> {
+            return Collections.singletonList(op.apply(payments.get(0)));
+        });
+    }
 
-        return paymentToDelete;
+    public static void withPayments(final int numberOfPayments,
+                                    final BlockingSphereClient client,
+                                    final UnaryOperator<PaymentDraftBuilder> builderMapping,
+                                    final UnaryOperator<List<Payment>> op) {
+        List<Payment> payments = IntStream.range(0, 2).mapToObj(ignore -> {
+            final PaymentDraft paymentDraft = builderMapping.apply(PaymentDraftBuilder.of(EUR_20)).build();
+            return client.executeBlocking(PaymentCreateCommand.of(paymentDraft));
+        }).collect(Collectors.toList());
+
+        List<Payment> paymentsToDelete = op.apply(payments);
+
+        for (Payment payment : paymentsToDelete) {
+            deleteWith409Retry(client, payment.getId(), payment.getVersion());
+        }
+    }
+
+    private static void deleteWith409Retry(final BlockingSphereClient client, final String id, Long version) {
+        while(true) {
+            try {
+                client.executeBlocking(PaymentDeleteCommand.of(Versioned.of(id, version)));
+                break;
+            } catch (ConcurrentModificationException e) {
+                version = e.getErrors().get(0).as(ConcurrentModificationError.class).getCurrentVersion();
+            } catch (Exception e) {
+                LOG.error("Exception while deleting payment[id='{}'] after test. Exception: {}", id, e.toString());
+                // ignore the error, since this helper method should not fail the tests
+                break;
+            }
+        }
+    }
+
+    public static void withPayments(int numberOfPayments, final BlockingSphereClient client, final UnaryOperator<List<Payment>> op) {
+        withPayments(numberOfPayments, client, a -> a, op::apply);
     }
 
     public static void withPayment(final BlockingSphereClient client, final UnaryOperator<Payment> op) {
-        withPayment(client, a -> a, op);
+        withPayments(1, client, a -> a, payments -> {
+            return Collections.singletonList(op.apply(payments.get(0)));
+        });
     }
 }

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/helper/CartAndMessageCreateHelper.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/helper/CartAndMessageCreateHelper.java
@@ -1,5 +1,6 @@
 package com.commercetools.paymenttoorderprocessor.helper;
 
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import com.commercetools.paymenttoorderprocessor.fixtures.CartFixtures;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageFilter;
 import com.commercetools.paymenttoorderprocessor.jobs.actions.MessageReader;
@@ -17,7 +18,6 @@ import io.sphere.sdk.payments.*;
 import io.sphere.sdk.payments.commands.PaymentUpdateCommand;
 import io.sphere.sdk.payments.commands.updateactions.AddTransaction;
 import io.sphere.sdk.payments.commands.updateactions.ChangeTransactionState;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 import io.sphere.sdk.queries.PagedQueryResult;
 import io.sphere.sdk.taxcategories.TaxCategory;
 import io.sphere.sdk.taxcategories.queries.TaxCategoryQuery;
@@ -78,7 +78,7 @@ public class CartAndMessageCreateHelper {
         final Payment paymentWithTransactionStateChange = testClient.executeBlocking(PaymentUpdateCommand.of(paymentWithTransaction, changeTransactionState));
 
         //final array so lambda can use it
-        final PaymentTransactionStateChangedMessage[] message = new PaymentTransactionStateChangedMessage[1];
+        final PaymentTransactionCreatedOrUpdatedMessage[] message = new PaymentTransactionCreatedOrUpdatedMessage[1];
 
         //Give Platform time to create messages
         try {

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilterTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/MessageFilterTest.java
@@ -1,6 +1,7 @@
 package com.commercetools.paymenttoorderprocessor.jobs.actions;
 
 import com.commercetools.paymenttoorderprocessor.customobjects.MessageProcessedManager;
+import com.commercetools.paymenttoorderprocessor.dto.PaymentTransactionCreatedOrUpdatedMessage;
 import com.commercetools.paymenttoorderprocessor.testconfiguration.ExtendedTestConfiguration;
 import com.commercetools.paymenttoorderprocessor.testconfiguration.HttpClientMockConfiguration;
 import com.commercetools.paymenttoorderprocessor.timestamp.TimeStampManager;
@@ -8,7 +9,6 @@ import com.commercetools.paymenttoorderprocessor.wrapper.CartAndMessage;
 import io.sphere.sdk.client.BlockingSphereClient;
 import io.sphere.sdk.json.SphereJsonUtils;
 import io.sphere.sdk.payments.Payment;
-import io.sphere.sdk.payments.messages.PaymentTransactionStateChangedMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,11 +55,11 @@ public class MessageFilterTest {
     @Autowired
     private MessageProcessedManager messageProcessedManager;
 
-    private PaymentTransactionStateChangedMessage testMessage;
+    private PaymentTransactionCreatedOrUpdatedMessage testMessage;
 
     @Before
     public void setUp() {
-        testMessage = SphereJsonUtils.readObjectFromResource("mocks/messageFilter/PaymentTransactionStateChangedMessage.json", PaymentTransactionStateChangedMessage.class);
+        testMessage = SphereJsonUtils.readObjectFromResource("mocks/messageFilter/PaymentTransactionStateChangedMessage.json", PaymentTransactionCreatedOrUpdatedMessage.class);
     }
 
     @Test

--- a/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/OrderCreatorIntegrationTest.java
+++ b/src/test/java/com/commercetools/paymenttoorderprocessor/jobs/actions/OrderCreatorIntegrationTest.java
@@ -56,92 +56,101 @@ public class OrderCreatorIntegrationTest {
 
     @Test
     public void writeWith201CreatedResult() throws Exception {
-        CartAndMessage cartAndMessage1 = cartAndMessageCreateHelper.createCartAndMessage(
-                PaymentFixtures.withPayment(testClient, builder -> builder.amountPlanned(EUR_20), a -> a));
+        PaymentFixtures.withPayment(testClient, builder -> builder.amountPlanned(EUR_20), payment -> {
+            CartAndMessage cartAndMessage1 = cartAndMessageCreateHelper.createCartAndMessage(payment);
 
-        httpClientMock.spyStatusCode(HttpStatusCode.CREATED_201);
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage1.getMessage())).isTrue();
-        orderCreator.write(Collections.singletonList(cartAndMessage1));
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage1.getMessage())).isFalse();
+            httpClientMock.spyStatusCode(HttpStatusCode.CREATED_201);
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage1.getMessage())).isTrue();
+            orderCreator.write(Collections.singletonList(cartAndMessage1));
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage1.getMessage())).isFalse();
 
-        // timestamp should be updated, because all operations were successful
-        timeStampManager.setActualProcessedMessageTimeStamp(cartAndMessage1.getMessage().getLastModifiedAt());
-        persistAndAssertTimestampEquals(cartAndMessage1.getMessage().getLastModifiedAt());
+            // timestamp should be updated, because all operations were successful
+            timeStampManager.setActualProcessedMessageTimeStamp(cartAndMessage1.getMessage().getLastModifiedAt());
+            persistAndAssertTimestampEquals(cartAndMessage1.getMessage().getLastModifiedAt());
 
-        ZonedDateTime now = ZonedDateTime.now();
-        timeStampManager.setActualProcessedMessageTimeStamp(now);
-        persistAndAssertTimestampEquals(now);
+            ZonedDateTime now = ZonedDateTime.now();
+            timeStampManager.setActualProcessedMessageTimeStamp(now);
+            persistAndAssertTimestampEquals(now);
+
+            return payment;
+        });
     }
 
     @Test
     public void writeWith200OkResult() throws Exception {
-        CartAndMessage cartAndMessage2 = cartAndMessageCreateHelper.createCartAndMessage(
-                PaymentFixtures.withPayment(testClient, builder -> builder.amountPlanned(USD_30), a -> a));
+        PaymentFixtures.withPayment(testClient, builder -> builder.amountPlanned(USD_30), payment -> {
+            CartAndMessage cartAndMessage2 = cartAndMessageCreateHelper.createCartAndMessage(payment);
 
-        httpClientMock.spyStatusCode(HttpStatusCode.OK_200);
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage2.getMessage())).isTrue();
-        orderCreator.write(Collections.singletonList(cartAndMessage2));
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage2.getMessage())).isFalse();
+            httpClientMock.spyStatusCode(HttpStatusCode.OK_200);
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage2.getMessage())).isTrue();
+            orderCreator.write(Collections.singletonList(cartAndMessage2));
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage2.getMessage())).isFalse();
 
-        // timestamp should be updated, because result is 200
-        timeStampManager.setActualProcessedMessageTimeStamp(cartAndMessage2.getMessage().getLastModifiedAt());
-        persistAndAssertTimestampEquals(cartAndMessage2.getMessage().getLastModifiedAt());
+            // timestamp should be updated, because result is 200
+            timeStampManager.setActualProcessedMessageTimeStamp(cartAndMessage2.getMessage().getLastModifiedAt());
+            persistAndAssertTimestampEquals(cartAndMessage2.getMessage().getLastModifiedAt());
 
-        ZonedDateTime now = ZonedDateTime.now();
-        timeStampManager.setActualProcessedMessageTimeStamp(now);
-        persistAndAssertTimestampEquals(now);
+            ZonedDateTime now = ZonedDateTime.now();
+            timeStampManager.setActualProcessedMessageTimeStamp(now);
+            persistAndAssertTimestampEquals(now);
+
+            return payment;
+        });
     }
 
     @Test
     public void writeWith400BadResult() throws Exception {
-        CartAndMessage cartAndMessage3 = cartAndMessageCreateHelper.createCartAndMessage(
-                PaymentFixtures.withPayment(testClient, builder -> builder.amountPlanned(UAH_42), a -> a));
+        PaymentFixtures.withPayment(testClient, builder -> builder.amountPlanned(UAH_42), payment -> {
+            CartAndMessage cartAndMessage3 = cartAndMessageCreateHelper.createCartAndMessage(payment);
 
-        timeStampManager.setActualProcessedMessageTimeStamp(cartAndMessage3.getMessage().getLastModifiedAt());
+            timeStampManager.setActualProcessedMessageTimeStamp(cartAndMessage3.getMessage().getLastModifiedAt());
 
-        httpClientMock.spyResponse(HttpStatusCode.BAD_REQUEST_400, "Test 400 bad response");
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
-        orderCreator.write(Collections.singletonList(cartAndMessage3));
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
-                .withFailMessage("Message should not be marked as processed")
-                .isTrue();
+            httpClientMock.spyResponse(HttpStatusCode.BAD_REQUEST_400, "Test 400 bad response");
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
+            orderCreator.write(Collections.singletonList(cartAndMessage3));
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
+                    .withFailMessage("Message should not be marked as processed")
+                    .isTrue();
 
-        timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
-        persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
+            timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
+            persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
 
-        httpClientMock.spyResponse(HttpStatusCode.FORBIDDEN_403, "Test 403 bad response");
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
-        orderCreator.write(Collections.singletonList(cartAndMessage3));
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
-                .withFailMessage("Message should not be marked as processed")
-                .isTrue();
+            httpClientMock.spyResponse(HttpStatusCode.FORBIDDEN_403, "Test 403 bad response");
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
+            orderCreator.write(Collections.singletonList(cartAndMessage3));
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
+                    .withFailMessage("Message should not be marked as processed")
+                    .isTrue();
 
-        // timestamp is not changeable any more, since above we had an error
-        timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
-        persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
+            // timestamp is not changeable any more, since above we had an error
+            timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
+            persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
 
-        httpClientMock.spyResponse(HttpStatusCode.BAD_GATEWAY_502, "Test 502 response");
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
-        orderCreator.write(Collections.singletonList(cartAndMessage3));
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
-                .withFailMessage("Message should not be marked as processed")
-                .isTrue();
+            httpClientMock.spyResponse(HttpStatusCode.BAD_GATEWAY_502, "Test 502 response");
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
+            orderCreator.write(Collections.singletonList(cartAndMessage3));
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
+                    .withFailMessage("Message should not be marked as processed")
+                    .isTrue();
 
-        // timestamp is not changeable any more, since above we had an error
-        timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
-        persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
+            // timestamp is not changeable any more, since above we had an error
+            timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
+            persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
 
-        httpClientMock.spyResponse(HttpStatusCode.CREATED_201);
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
-        orderCreator.write(Collections.singletonList(cartAndMessage3));
-        assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
-                .withFailMessage("Message should be marked as processed")
-                .isFalse();
+            httpClientMock.spyResponse(HttpStatusCode.CREATED_201);
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage())).isTrue();
+            orderCreator.write(Collections.singletonList(cartAndMessage3));
+            assertThat(messageProcessedManager.isMessageUnprocessed(cartAndMessage3.getMessage()))
+                    .withFailMessage("Message should be marked as processed")
+                    .isFalse();
 
-        // even if the last operation is success - timestamp should not be untouched,
-        // because previous operations failed
-        timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
-        persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
+            // even if the last operation is success - timestamp should not be untouched,
+            // because previous operations failed
+            timeStampManager.setActualProcessedMessageTimeStamp(ZonedDateTime.now());
+            persistAndAssertTimestampEquals(cartAndMessage3.getMessage().getLastModifiedAt());
+
+            return payment;
+        });
     }
 
     private void persistAndAssertTimestampEquals(ZonedDateTime actualProcessedMessageTimeStamp) {


### PR DESCRIPTION
## The problem
PaymentTransactionStateChangedMessage is not triggered when a transaction is added to the payment. In this case only PaymentTransactionAddedMessage is triggered. However, the processor does not react to these messages and no order is created. In Adyen we often only create a successful payment transaction and do not update it later. That's why the processor does not work correctly for adyen.

## The solution
Since both messages are quite similar, I created a wrapper for both of them and use it everywhere: https://github.com/commercetools/commercetools-payment-to-order-processor/pull/71/files#diff-026967b3b2d039b83d87b8dda429a9cecb01979394c1886ed5aa6426c9c4c5d6

I also fetch now both messages from CTP: https://github.com/commercetools/commercetools-payment-to-order-processor/pull/71/files#diff-65bef2d220f7dfe37d656e1c24cf92cd8807e747c672ac37e555b468f905a55bR131

I added integration test for the batch job: https://github.com/commercetools/commercetools-payment-to-order-processor/pull/71/files#diff-78fa7cafd7458ce813408b9fd851a7c9d0c6ccc874a06673c11e110bd055c02c

I tried to improve the tests, but it's too much, so for now it's only half improved. There will be another ticket for this improvement.