### PR TITLE
Fix docker repo name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: commercetools/commercetools-payment-to-order-processor:${{ steps.vars.outputs.tag }}
+          tags: commercetools/payment-to-order-processor:${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
Docker repo name should be `commercetools/payment-to-order-processor`