### PR TITLE
Change base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:8-jre-alpine
+FROM amazoncorretto:8-alpine-jre
 COPY target/payment-to-order-processor.jar /payment-to-order-processor.jar
 CMD ["java", "-Xms16m", "-Xmx32m", "-jar", "/payment-to-order-processor.jar"]


### PR DESCRIPTION
**Complication**
We use openjdk (https://hub.docker.com/_/openjdk) to build docker image.
However, openjdk is deprecated. It is not updated anymore and it is recommended to replace it with another java distribution. 

**Evaluation**
[✓] Amazon Corretto - Although our application is not for crypto purpose and not deployed to AWS, the processor can be executed successfully in local machine with this base docker image. Also it doesn't have other disadvantage as other base images, so we would pick this choice.

[ X ] Adoptium Eclipse Temurin - It is formal successor of AdoptOpenJDK. It uses Hotspot JVM as same as OpenJDK, and it keeps continue to provide latest binaries. However, when we adapt this base docker image and run the job in local machine, it throws errors and the processor cannot be executed successfully, so we would not choose it.

Stacktrace
```
java.util.concurrent.CompletionException: io.sphere.sdk.http.HttpException: The underlying HTTP client detected a problem.
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:607)
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:591)
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488)
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1990)
	at io.sphere.sdk.http.HttpClientAdapterBase.lambda$execute$1(HttpClientAdapterBase.java:56)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:774)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:750)
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488)
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1990)
	at io.sphere.sdk.http.ResponseAsyncCompletionHandler.onThrowable(ResponseAsyncCompletionHandler.java:23)
	at org.asynchttpclient.netty.NettyResponseFuture.abort(NettyResponseFuture.java:247)
	at org.asynchttpclient.netty.channel.NettyConnectListener.onFailure(NettyConnectListener.java:170)
	at org.asynchttpclient.netty.channel.NettyConnectListener$1.onFailure(NettyConnectListener.java:139)
	at org.asynchttpclient.netty.SimpleFutureListener.operationComplete(SimpleFutureListener.java:26)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:507)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:500)
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:479)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:420)
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:122)
	at io.netty.handler.ssl.SslHandler.notifyHandshakeFailure(SslHandler.java:1480)
	at io.netty.handler.ssl.SslHandler.setHandshakeFailure(SslHandler.java:1470)
	at io.netty.handler.ssl.SslHandler.setHandshakeFailure(SslHandler.java:1442)
	at io.netty.handler.ssl.SslHandler.handleUnwrapThrowable(SslHandler.java:1135)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1114)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1143)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:491)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:430)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:335)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1302)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:135)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:646)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:498)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:460)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:131)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.sphere.sdk.http.HttpException: The underlying HTTP client detected a problem.
	at io.sphere.sdk.http.HttpClientAdapterBase.lambda$execute$1(HttpClientAdapterBase.java:53)
	... 38 common frames omitted
Caused by: java.net.ConnectException: Received fatal alert: handshake_failure
	at org.asynchttpclient.netty.channel.NettyConnectListener.onFailure(NettyConnectListener.java:168)
	... 31 common frames omitted
Caused by: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
	at sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at sun.security.ssl.Alert.createSSLException(Alert.java:117)
	at sun.security.ssl.TransportContext.fatal(TransportContext.java:311)
	at sun.security.ssl.Alert$AlertConsumer.consume(Alert.java:293)
	at sun.security.ssl.TransportContext.dispatch(TransportContext.java:185)
	at sun.security.ssl.SSLTransport.decode(SSLTransport.java:152)
	at sun.security.ssl.SSLEngineImpl.decode(SSLEngineImpl.java:588)
	at sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:544)
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:411)
	at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:390)
	at javax.net.ssl.SSLEngine.unwrap(SSLEngine.java:626)
	at io.netty.handler.ssl.SslHandler$SslEngineType$3.unwrap(SslHandler.java:283)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1197)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1108)
	... 19 common frames omitted

```

[ X ] SapMachine - Our application is not for SAP purpose. And the most important is that it doesn't provide Java 8 base docker image. Not much advantages of using it.

[ X ] IBM Semeru Runtime / IBM Java - It uses OpenJ9 virtual machine which is different from default Hotspot JVM. In additions, it is well-known for its slower execution time than Hotspot JVM although it consumes less memory.