### PR TITLE
Upgrade Java for Temurin JRE-11 Adatpion

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,10 +21,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
+          distribution: temurin
       - name: Build with Maven
         run: mvn verify
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
         same-branch-only: false
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
+        distribution: temurin
     - name: Build with Maven
       run: mvn verify
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM amazoncorretto:8-alpine-jre
+FROM eclipse-temurin:11-alpine
 COPY target/payment-to-order-processor.jar /payment-to-order-processor.jar
 CMD ["java", "-Xmx256m", "-jar", "/payment-to-order-processor.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -8,18 +8,18 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.10.RELEASE</version>
+        <version>1.5.22.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <logStashLogbackEncoder.version>6.6</logStashLogbackEncoder.version>
-     <logback-json-classic.version>1.2.4-groovyless</logback-json-classic.version>
-        <jul-to-slf4.version>1.7.32</jul-to-slf4.version>
-        <commercetools-jvm-sdk.version>2.0.0</commercetools-jvm-sdk.version>
+        <logback-json-classic.version>1.2.11</logback-json-classic.version>
+        <jul-to-slf4.version>1.7.36</jul-to-slf4.version>
+        <commercetools-jvm-sdk.version>2.9.0</commercetools-jvm-sdk.version>
     </properties>
 
     <packaging>jar</packaging>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.14</version>
+            <version>1.15</version>
         </dependency>
         <!--logging-->
         <dependency>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
-            <version>3.3.9</version>
+            <version>3.8.6</version>
         </dependency>
 
         <!-- Compile time validation -->
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
+            <version>3.23.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Adapt Java 11 in maven, with upgraded dependencies
- Use Temurin JDK 11 in CI/CD
- Adapt Temurin JRE 11 alpine as base docker image

Already tested with classes compiled by Temurin JDK 11, and run the docker image with Temurin JRE 11 alpine in local machine. The SSH issue happened in Temurin JRE 8 is eliminated.